### PR TITLE
resolve License conflict #1

### DIFF
--- a/qpm.json
+++ b/qpm.json
@@ -4,7 +4,7 @@
   "dependencies": [
     "com.sonrisesoftware.quickly@0.0.5"
   ],
-  "license": "NONE",
+  "license": "MPL_2_0",
   "pri_filename": "",
   "webpage": ""
 }


### PR DESCRIPTION
https://github.com/quickly/quickly-skeleton/issues/1
INFO: Package com.sonrisesoftware.quickly has a different license (MPL_2_0) than it's dependant (NONE).
WARNING: The MPL_2_0 license requires distribution of source code in some cases.